### PR TITLE
Create http_top.conf

### DIFF
--- a/Getipinfo.py
+++ b/Getipinfo.py
@@ -25,7 +25,7 @@ Country = response.country.name
 Zip = response.postal.code
 IP = str(sys.argv[1])
 Domain = str(sys.argv[2])
-duration = int(sys.argv[3])
+time = int(sys.argv[3])
 print (Country)
 print (State)
 print (City)
@@ -57,8 +57,7 @@ hostname = socket.gethostname()
 measurement_name = ("ReverseProxyConnections")
 print (measurement_name)
 print ('*************************************')
-# take a timestamp for this measurement
-time = datetime.datetime.utcnow()
+
 
 # format the data as a single measurement for influx
 body = [
@@ -84,7 +83,6 @@ body = [
             "key": ISO,
             "IP": IP,
             "name": Country,
-            "duration": duration,
             "metric": 1
         }
     }

--- a/http_top.conf
+++ b/http_top.conf
@@ -1,0 +1,39 @@
+log_format json_analytics escape=json '{'
+                            '"msec": "$msec", ' # request unixtime in seconds with a milliseconds resolution
+                            '"connection": "$connection", ' # connection serial number
+                            '"connection_requests": "$connection_requests", ' # number of requests made in connection
+                    '"pid": "$pid", ' # process pid
+                    '"request_id": "$request_id", ' # the unique request id
+                    '"request_length": "$request_length", ' # request length (including headers and body)
+                    '"remote_addr": "$remote_addr", ' # client IP
+                    '"remote_user": "$remote_user", ' # client HTTP username
+                    '"remote_port": "$remote_port", ' # client port
+                    '"time_local": "$time_local", '
+                    '"time_iso8601": "$time_iso8601", ' # local time in the ISO 8601 standard format
+                    '"request": "$request", ' # full path no arguments if the request
+                    '"request_uri": "$request_uri", ' # full path and arguments if the request
+                    '"args": "$args", ' # args
+                    '"status": "$status", ' # response status code
+                    '"body_bytes_sent": "$body_bytes_sent", ' # the number of body bytes exclude headers sent to a client
+                    '"bytes_sent": "$bytes_sent", ' # the number of bytes sent to a client
+                    '"http_referer": "$http_referer", ' # HTTP referer
+                    '"http_user_agent": "$http_user_agent", ' # user agent
+                    '"http_x_forwarded_for": "$http_x_forwarded_for", ' # http_x_forwarded_for
+                    '"http_host": "$http_host", ' # the request Host: header
+                    '"server_name": "$server_name", ' # the name of the vhost serving the request
+                    '"request_time": "$request_time", ' # request processing time in seconds with msec resolution
+                    '"upstream": "$upstream_addr", ' # upstream backend server for proxied requests
+                    '"upstream_connect_time": "$upstream_connect_time", ' # upstream handshake time incl. TLS
+                    '"upstream_header_time": "$upstream_header_time", ' # time spent receiving upstream headers
+                    '"upstream_response_time": "$upstream_response_time", ' # time spend receiving upstream body
+                    '"upstream_response_length": "$upstream_response_length", ' # upstream response length
+                    '"upstream_cache_status": "$upstream_cache_status", ' # cache HIT/MISS where applicable
+                    '"ssl_protocol": "$ssl_protocol", ' # TLS protocol
+                    '"ssl_cipher": "$ssl_cipher", ' # TLS cipher
+                    '"scheme": "$scheme", ' # http or https
+                    '"request_method": "$request_method", ' # request method
+                    '"server_protocol": "$server_protocol", ' # request protocol, like HTTP/1.1 or HTTP/2.0
+                    '"pipe": "$pipe", ' # "p" if request was pipelined, "." otherwise
+                    '"gzip_ratio": "$gzip_ratio", '
+                    '"http_cf_ray": "$http_cf_ray"'
+                    '}';

--- a/sendips.sh
+++ b/sendips.sh
@@ -15,7 +15,7 @@ else
 fi
 
 # Tail the custom log location to allow json parsing of the custom logs
-tail -f /logs/json/*.log | while read line;
+tail -f /logs/*-json.log | while read line;
 
 do
   #get requested domain from json log and remove the leading and trailing quotes

--- a/sendips.sh
+++ b/sendips.sh
@@ -1,26 +1,54 @@
-#!/bin/sh
+#!/bin/bash
 # " /bin/sh /Shared/nginx/shtail.sh & " needs to be added to /startapp.sh as the second line
 # for ipv6 and ipv4 grep -E -o "(([0-9]{1,3}[\.]){3}[0-9]{1,3}|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))" file.txt
 # for ipv6 and ipv4 exluding homeips grep -E -o "(([0-9]{1,3}[\.]){3}[0-9]{1,3}|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))" | grep -v "192.168.0.*\| 69.0.0.* \| 5.0.0.*" file.txt 
 # for domains grep -E -o "[a-z0-9]*\.[a-z0-9]*\.(de|net|org|com)" file.txt #working for domains
-tail -f /logs/proxy_host* | grep -E "([0-9]{1,3}[\.]){3}[0-9]{1,3}" | while read line;
+
+# Check if jq is installed and executable, if not install it and set as executable.  This allows us to parse the json logs
+if [[ -x "/usr/bin/jq" ]]
+then
+    echo "jq available"
+else
+    echo "jq is not executable or found, installing"
+    curl -L -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+    chmod +x /usr/bin/jq
+fi
+
+# Tail the custom log location to allow json parsing of the custom logs
+tail -f /logs/json/*.log | while read line;
+
 do
-  domain=`echo ${line:0:80} | grep -m 1 -o -E "[a-z0-9]*\.[a-z0-9]*\.(de|net|org|com)"`
-  ipaddressnumber=`echo $line | grep -o -m 1 -E "(([0-9]{1,3}[\.]){3}[0-9]{1,3}|([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))" | grep -v "$HOME_IPS"`  ##UPDATE grep -v with local network
-  length=`echo $line | awk -F ' ' '{print$14}' | grep -m 1 -o '[[:digit:]]*'`
-  #device=`echo $line | grep -e ""'('*')'""`
-  #echo $HOME_IPS
-  echo $length
-  echo $ipaddressnumber 
+  #get requested domain from json log and remove the leading and trailing quotes
+  domain=`echo $line | jq '.http_host'  | sed 's/.\(.*\)/\1/' | sed 's/\(.*\)./\1/'`
+  #get requesting IP from json log and remove the leading and trailing quotes
+  ipaddressnumber= `echo $line | jq '.remote_addr'  | sed 's/.\(.*\)/\1/' | sed 's/\(.*\)./\1/'`
+  #get actual time the request was made from json log and remove the leading and trailing quotes
+  reqtime=`echo $line | jq '.time_iso8601' | sed 's/.\(.*\)/\1/' | sed 's/\(.*\)./\1/'`
+  
+  #Print on screen captured values
+  echo $reqtime
+  echo $ipaddressnumber
   echo $domain
-  #echo $dev
-  #HomeIP='192.168.0.24' #HomeIP is used to not send your home public ip to keep the number of sends down
-  #myhomeIP=$(wget -qO- https://icanhazip.com/)
-  #if [[ "$ipaddressnumber" == "$myhomeIP" ]]
-  #then
-  #  echo "Home IP"
-  #else
-    python /root/.config/NPMGRAF/Getipinfo.py "$ipaddressnumber" "$domain" "$length"
-  #fi
+  
+  #Get public IP4 and IP6 addresses, so we can avoid sending IPs from our own connection
+  myhomeIP4=$(wget -qO- https://ipv4.icanhazip.com/)
+  myhomeIP6=$(wget -qO- https://ipv6.icanhazip.com/)
+  
+   if [[ "$ipaddressnumber" == "$myhomeIP4" ]]
+  then
+    echo "Home IP4"
+  elif [[ "$ipaddressnumber" == "$myhomeIP6" ]]
+  then
+    echo "Home IP6"
+  #LanIP is used to not send your home network ips to keep the number of sends down, edit this to represent your subnet BUT DO NOT REMOVE THE "^" at the start as this represents "starts with" in the regex  
+  elif [[ "$ipaddressnumber" =~ ^192.168.0.* ]]
+  then
+    echo "LAN IP"
+  elif [[ -z "$ipaddressnumber" ]]
+  then
+    echo "IP null"
+  else
+    python /root/.config/NPMGRAF/Getipinfo.py "$ipaddressnumber" "$domain" "$reqtime"
+  fi
 done
 reboot

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo "lets go and send connection info to influx"
-sh $NPMGRAF_HOME/sendips.sh
+bash $NPMGRAF_HOME/sendips.sh
 
 sleep 0.5
 tee $NPMGRAF_HOME/nohup.out > /proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
This is a fork which uses a custom json schema to allow a json log format to be output from npm.
It should be placed in /data/nginx/custom/http_top.conf
This will allow a line to be placed in the advanced tab for each proxy host will enable custom logs.
The line that should be added is:   "access_log /data/logs/PROXYNAME-json.log json_analytics;"
where PROXYNAME should be replaced with the name you want to use.
start.sh, sendips.sh and Getinfo.py have all been changed to allow the use of json parsing, including checking for and installing jq and also using bash instead of sh.
